### PR TITLE
Cache Socket.gethostname call, it can be slow enough to cause connect…

### DIFF
--- a/lib/faktory/client.rb
+++ b/lib/faktory/client.rb
@@ -245,7 +245,7 @@ module Faktory
 
       payload = {
         "wid": @@random_process_wid,
-        "hostname": Socket.gethostname,
+        "hostname": hostname,
         "pid": $$,
         "labels": Faktory.options[:labels] || ["ruby-#{RUBY_VERSION}"],
         "v": 2,
@@ -276,6 +276,10 @@ module Faktory
 
       command("HELLO", Faktory.dump_json(payload))
       ok
+    end
+
+    def hostname
+    	@@hostname ||= Socket.gethostname
     end
 
     def command(*args)


### PR DESCRIPTION
My machine was occasionally taking 5 seconds to do the `Socket.gethostname` call which is longer than faktory will wait for a response. I assume using the class instance variable here is ok since the hostname shouldn't be changing on the fly but I'm not 100% sure that's the case in all environments.